### PR TITLE
Automatic selectors transformations:

### DIFF
--- a/src/Carrefour-Fortran/CRFFBindingCleaner.class.st
+++ b/src/Carrefour-Fortran/CRFFBindingCleaner.class.st
@@ -27,9 +27,8 @@ CRFFBindingCleaner >> cleanModel: fastModel [
 { #category : 'search famix' }
 CRFFBindingCleaner >> rootEntitiesIn: aFASTFortranModel [
 
-	^aFASTFortranModel entities select: [ :entity |
-		entity parents isEmpty
-	]
+	^aFASTFortranModel entities
+		select: [ :entity | entity containers isEmpty ]
 ]
 
 { #category : 'visiting - statements' }

--- a/src/Carrefour-Fortran/CRFFortranProgramUnitBinderVisitor.class.st
+++ b/src/Carrefour-Fortran/CRFFortranProgramUnitBinderVisitor.class.st
@@ -23,7 +23,7 @@ CRFFortranProgramUnitBinderVisitor >> bindFastModel: fastModel toFamixEntity: aF
 CRFFortranProgramUnitBinderVisitor >> childrenEntities: aFamixClass named: aName [
 	"note that famixEntity's 'children' include the famixEntity itself"
 
-	^(famixEntity allToScope: aFamixClass)
+	^(famixEntity allContainedEntitiesOfType: aFamixClass) 
 		select: [ :each | each name sameAs: aName ]
 ]
 
@@ -75,7 +75,7 @@ CRFFortranProgramUnitBinderVisitor >> famixEntity: anObject [
 CRFFortranProgramUnitBinderVisitor >> rootEntitiesIn: fastModel [
 
 	^(fastModel allWithSubTypesOf: FASTFortranProgramUnit)
-		select: [ :entity | entity parents isEmpty ]
+		select: [ :entity | entity containers isEmpty ]
 ]
 
 { #category : 'visiting' }


### PR DESCRIPTION
- from `parents` to `containers`
- from `allToScope:` to `allContainedEntitiesOfType:`